### PR TITLE
use curl instead of wget

### DIFF
--- a/nix-in-termux
+++ b/nix-in-termux
@@ -52,7 +52,7 @@ if [ ! -x "$DIVE_SCRIPT" ]; then
 	mkdir -p "$PLAYGROUND" || oops "failed to create $PLAYGROUND"
 
 	echo "installing tools..."
-	pkg install -y proot bzip2 tar wget || oops "failed to install required tools"
+	pkg install -y proot bzip2 tar curl || oops "failed to install required tools"
 
 	tmpDir="$PLAYGROUND/tmp"
 	mkdir -p "$tmpDir" || oops "false to create $tmpDir"
@@ -79,7 +79,7 @@ if [ ! -x "$DIVE_SCRIPT" ]; then
 	#tarball="$HOME/nix-2.2.1-$system.tar.bz2"
 
 	echo "downloading Nix 2.2.1 binary tarball for $system from '$url' to '$tmpDir'..."
-	$TERMUX_BIN/wget "$url" -O "$tarball" || oops "failed to download '$url'"
+	$TERMUX_BIN/curl -Lo "$tarball" "$url" || oops "failed to download '$url'"
 
         hash2="$(sha256sum -b "$tarball" | cut -c1-64)"
 


### PR DESCRIPTION
I'm getting an SSL issue with wget, curl works fine

```console
downloading Nix 2.2.1 binary tarball for aarch64-linux from 'https://nixos.org/releases/nix/nix-2.2.1/nix-2.2.1-aarch64-linux.tar.bz2' to '/data/data/com.termux/files/home/.nix/tmp'...
--2019-03-02 12:30:38--  https://nixos.org/releases/nix/nix-2.2.1/nix-2.2.1-aarch64-linux.tar.bz2
Disabling SSL due to encountered errors.
./nix-in-termux: failed to download 'https://nixos.org/releases/nix/nix-2.2.1/nix-2.2.1-aarch64-linux.tar.bz2'
```